### PR TITLE
fix: increase z-index for modal

### DIFF
--- a/src/containers/Modal.module.scss
+++ b/src/containers/Modal.module.scss
@@ -8,6 +8,7 @@
 
 .overlay {
   @include flex;
+  z-index: 2;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
**Description:**
Fix for z-index [issue](https://github.com/Mirror-Protocol/terra-web-app/issues/7)

**Changes:**
add `z-index: 2` in Modal.module.scss overlay class

**Result:**
<img width="829" alt="wallet-install-modal" src="https://user-images.githubusercontent.com/8136256/114265691-dc45e380-9a24-11eb-9f16-60e384c0a92b.png">


